### PR TITLE
Trace of nuts warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ Telemetry & more for the glorious, best, totally-rpg [FunnyGuilds](https://githu
 This project:
 - may or may not work,
 - may or may not contain gluten,
+- may or may not contain traces of nuts,
 - may or may not randomly injure people in a 15 meter radius, and
-- may or may not be safe for children under the age of 12.
+- may or may not be safe for children under the age of 12


### PR DESCRIPTION
'May contain nuts/trace of nuts' warnings are becoming ever more complex and ever more difficult to interpret. It is not nuts themselves that are the problem, but the confusion arising from the laudable efforts of regulators and manufacturers to improve allergen labelling for the benefit of allergic consumers. But, nuts being at the sharp end of the allergy experience, nut labelling takes much of the flak.

Nut/peanut allergy is very emotive.
It is the one allergy that almost everyone has heard of – and what they have heard is that it can kill you. In reality, any serious allergy can kill you but nuts/peanuts are the most common killers. So manufacturers (and food service operatives) are super nervous about getting involved with nuts and especially about making any claims.

For example, Kinnerton chocolate, although they were the first company, fifteen years ago, to spend over a £1 million building a dedicated nut free section onto their factory, will not make a 'nut free' claim. Instead they make a 'Nut Safety Promise' and then spend a page of their website explaining how they try to make their products safe for nut allergy sufferers.

Similarly, many readers this blog will remember the brouhaha last year when Alpro decided to move the manufacture of their nut milks onto the same site as their soya milks – a site which had previously not used nuts so that their soya milks could be declared 'nut free'. Despite the fact that the protocols they were proposing to use were extremely tight so that the risk of nut contamination would have fallen well below the level suggested by the Food Standards Agency as triggering a 'may contain nuts' warning, they were insistent that any product manufactured on the same premises as a nut milk should carry a nut warning. The situation was finally resolved not by a labelling accommodation, but by Alpro deciding not to combine manufacture of their nut and soya milk so that the soya milk site could remain nut free.

So if manufacturers do decide to supply this market they need to understand exactly what is involved in manufacturing allergen-free products.

Way back.... Nuts as an ingredient

Back in the day, if a product did not have nuts/peanuts as an ingredient it could deemed to be nut free. But as the number of nut/peanut allergics grew, so did the understanding of how little of the allergic protein it takes to cause a reaction in someone who is seriously allergic. So could a chip of nut/peanut from another product line which strayed into a product which did not have nuts as an ingredient cause a problem? Well, yes it could. So no longer was it enough for the product not to contain nuts/peanuts as an ingredient. If it was to avoid any chips of nuts or peanuts getting in by mistake, it really needed to be made in a facility which never used nuts/peanuts and was therefore totally nut/peanut free.

No nuts in the ingredients; no nuts in the factory

So now we have two sets of nut/peanut-free products: those that are made in a nut/peanut free factory and those that are made in a factory which also uses nuts/peanuts. Can the latter really be safe for nut/peanut allergics?

This is not an easy question to answer as it depends not only on the rigour of the cleaning and manufacturing protocols in the factory but on what they are actually manufacturing. So, for example, the Alpro nut/soya milk would have been fine as it is perfectly possible to clean down equipment that has been used for a liquid product such as a nut milk to guarantee that there will be no residue. However, were you making chocolate it would be a totally different matter. Chocolate is notoriously sticky and difficult to clean and no matter how wonderful your cleaning protocols, it would be impossible to guarantee that there would be no peanut/nut residues.

But the allergen labelling on these products does not tell you any of this so you have no way of assessing the risk you might be running in eating a nut/peanut-free product with a 'made in a factory that also uses nuts' warning on it.

So, which do you buy?

So, what do you as a nut/peanut allergic yourself, or as the parent of a nut/peanut allergic child, do? Play it safe and only buy products made in a dedicated nut/peanut-free environment? Or do you research the product and the factory and make your own decision based on the product (milk or chocolate) and how efficient you think the factory's cleaning protocols may be? (An option which will involve you in a lot of work in talking to manufacturers and learning about cleaning methods and ingredients.) Or do you risk it anyhow and just hope that if there is any nut/peanut contamination, you won't be the unlucky person who gets to eat it?

Play it safe

Hardly surprisingly, the advice given by the Anaphylaxis Campaign, and followed by most parents of allergic children, is to take no risks and to stick with products which are made in a nut free environment. This is absolutely right and sensible, but will inevitably mean that that these people will miss out on a significant number of products which actually would be perfectly safe for them to eat. But, it no longer stops there.

Transparency and traceability

Over the last few years and as a result of Horsegate and innumerable other food scandals (none of them anything to do with allergy), traceability has become the buzz word in the food industry. It is no longer enough to know what you do in your own factory, you need to know what happens further back down the chain, how your suppliers make up the ingredients that you use (is the beef really beef or is it horse?), and how their suppliers grow their raw materials.

How is this relevant for allergy? Well, take the case of oats. If a field of oats is grown next door to a field of wheat, there is absolutely no way that you can avoid some of the wheat getting into the oats and some of the oats getting into the wheat. But while oats getting into wheat does not matter to wheat eaters, wheat getting in among the oats does matter to coeliacs who have now been cleared to eat oats. So it is essential that the manufacturer of a gluten-free, oat-containing product knows exactly where their oats have been grown.

So a label does not only need to tell the consumer whether there are any allergens deliberately included in the product, it needs to tell that consumer whether or not the allergen is used in the factory in which the product is made and whether, way back down the supply chain, the ingredients have ever come into contact with the allergen and could therefore have been contaminated by it. But once again, the variables are enormous.

The chances of wheat contamination in a field of oats grown next door to the wheat (or milled the same mill as the wheat) is very high. But that may not always be the case. If the ingredient is very heavy or solid, then it is unlikely to blow around (as would the wheat) or spill out of containers, so the contamination risk could be very low.

And another problem. If the ingredient comes from another country where transparency and labelling is not as stringent as it is in the UK/Europe (as many 'freefrom' ingredients do) there may be no way of finding out whether or not it could have been contaminated by an allergen as no records will exist. And what if this ingredient is only used in a tiny quantity so even if it were contaminated the amount of protein would be vanishingly small?

In either case, even though the ingredient may in fact be totally safe, the honest manufacturer using it will not be able to declare that the ingredients are totally nut/peanut/relevant allergen free as they cannot prove it – and will therefore have to add a nut warning.

The fall out in practice

peanutsThis whole question arose during the course of the FreeFrom Food Awards 'products manufactured for nut nut/peanut allergics' category judging in February. Among the judges were Moira Austin who has run the Anaphylaxis Campaign help line since the charity was started 20 years ago, Alexa of Yes,NoBananas and Louise of NutMums, both parents of nut/peanut allergic children.

One of the 'freefrom nuts/peanuts' entered products had declared that there were no nuts in the ingredients and that it was manufactured in a factory which did not use nuts, but that it could not guarantee that the ingredients were free of nut contamination. As far as we could see, the only ingredient that would have been at issue was the Brazilian orange oil for which it would be very unlikely that you would be able to get any reliable history. But, they would form a very tiny part of the whole product.

Louise said, reasonably enough, that 'nut free' meant 'nut free', not partly nut free and if you could not guarantee that all of the ingredients were free of nut contamination, then you should not call a product 'nut/peanut free'.

But Alexa suggested that even nut allergics need to live in the real world and, realistically, the risk of nut contamination of an ingredient used in such a tiny quantity was so small that it did not present a 'real' risk. She maintained that the manufacturer should be congratulated on being so open and transparent and that the allergic person wanting to buy the product should make their own informed assessment of the risk and act accordingly. A perfectly reasonable and sensible suggestion – provided that you are both willing and able to make that assessment and are comfortable with the responsibility of making the choice.

The Anaphylaxis Campaign's position is that manufacturers should follow the very good guidelines set down by the Food Standards Agency which state that 'advisory labelling on possible cross-contamination with allergens should be justifiable only on the basis of a risk assessment applied to a responsibly managed operation. Warning labels should only be used where there is a demonstrable and significant risk of allergen cross- contamination and they should not be used as a substitute for Good Manufacturing Practices'.

If this principle were applied throughout the 'freefrom' industry, life would certainly be a great deal simpler for the allergic consumer. They could then believe that a 'may contain' warning, when it appeared, did indicate a significant level of risk and they could assume if it did not appear, then they could eat the product safely. Sadly, we are as yet a long way from this as a uniform practice. So for now we continue to get a confusing jumble of messages which range from the ultra-responsible manufacture quoted above who is going over and above and thereby frightening off people who could almost certainly eat their product perfectly safely, to the lazy/frightened manufacturer who is using 'may contain' labelling as a 'substitute for Good Manufacturing Practices' and whose product may not be even remotely safe. All extraordinarily confusing for the allergy community.

One can only hope that the situation gradually settle down as 'freefrom' manufacturers become more sophisticated, the concept of detailed risk assessment becomes more widely understood and practised and more 'dedicated' nut/peanut/ gluten/dairy etc facilities are built. What would also help enormously would be EU agreement on, and implementation of, allergen thresholds or 'action levels' for allergens other than gluten so that both manufacturers and consumers know what 'freefrom' actually means and can work towards it.